### PR TITLE
Adding GPU device mapping to NAS

### DIFF
--- a/orchestration/playbooks/templates/compose-nas.yaml
+++ b/orchestration/playbooks/templates/compose-nas.yaml
@@ -17,6 +17,8 @@ services:
       - 8920:8920 #optional
       - 7359:7359/udp #optional
       - 1900:1900/udp #optional
+    devices:
+      - /dev/dri:/dev/dri
     restart: unless-stopped
 
   transmission:


### PR DESCRIPTION
Now 4k videos can transcode within 35-40 fps range, dope.