### PR TITLE
Bring pi (agent) config under Home Manager

### DIFF
--- a/home-manager/pi/AGENTS.md
+++ b/home-manager/pi/AGENTS.md
@@ -1,0 +1,13 @@
+# Global agent guidelines
+
+## Git
+- Every repository is managed by git.
+- Do NOT commit, rebase, merge, or otherwise modify commit history without an explicit request from the user.
+
+## just
+- Prefer `just` for common repository tasks.
+- Only use other tools when the `Justfile` (or other `just` config) does not cover what's needed.
+
+## mise
+- Prefer `mise` to manage and run required tools.
+- Do NOT modify `mise.toml` or other `mise` configuration without explicit approval.

--- a/home-manager/pi/skills/create-pr/SKILL.md
+++ b/home-manager/pi/skills/create-pr/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: create-pr
+description: Create a pull request (GitHub) or merge request (GitLab) for the current git branch using the forge's CLI (gh/glab). Detects the forge from git remotes, diffs the current branch against the default branch, and drafts a title and body for the human to review. Use when the user asks to open/create a PR, MR, pull request, or merge request.
+---
+
+# Create PR / MR
+
+Open a pull request (GitHub) or merge request (GitLab) for the current branch
+using the forge's CLI, after drafting a title/body from the branch diff for the
+operator to review and approve.
+
+## Core rules
+
+- **Never proceed without explicit human approval** of the drafted title and body.
+- **Do not verify whether the branch was pushed.** Use a try-and-see approach:
+  just run the CLI create command. If the CLI complains the branch is missing on
+  the remote, report that and let the user decide whether to push.
+- **Bail if the required CLI tool cannot be found** in `~/.nix-profile/bin`, via
+  `mise exec`, or system-wide (`/usr/local/bin`, `/usr/bin`).
+- **If the forge is unclear, stop and ask the user.** Do not guess.
+- **If the diff is empty, stop and ask the user.** Do not open an empty PR/MR.
+
+All scripts below live in this skill's `scripts/` directory. Invoke them with
+their path relative to this SKILL.md.
+
+## Workflow
+
+### 1. Detect the forge
+
+```bash
+./scripts/detect-forge.sh          # prints: github | gitlab | unknown
+git remote -v                      # for context / self-hosted inspection
+```
+
+If the result is `unknown` (e.g. a self-hosted instance whose hostname does not
+contain `github`/`gitlab`), **elicit feedback from the user**: show them the
+remotes and ask which forge this is. Do not continue until it is clear.
+
+### 2. Resolve the CLI tool
+
+- GitHub → `gh`
+- GitLab → `glab`
+
+```bash
+./scripts/resolve-tool.sh gh       # or: ./scripts/resolve-tool.sh glab
+```
+
+The script prints the command prefix to use (an absolute path, or
+`mise exec -- gh`). **If it exits non-zero, bail** and tell the user the tool is
+not installed in any allowed location. Use exactly the printed prefix for every
+CLI invocation.
+
+### 3. Determine branches and compute the diff
+
+```bash
+CURRENT=$(git rev-parse --abbrev-ref HEAD)
+DEFAULT=$(./scripts/default-branch.sh)     # e.g. main; empty if undetermined
+```
+
+If `DEFAULT` is empty, ask the user for the target/base branch.
+
+Compute the diff of the current branch against the default branch. Prefer the
+merge-base so only this branch's changes are considered:
+
+```bash
+git diff --stat "$DEFAULT"...HEAD
+git log --oneline "$DEFAULT"..HEAD
+git diff "$DEFAULT"...HEAD          # full diff for drafting the body
+```
+
+**If the diff is empty** (no changes and no commits between the branches),
+**elicit feedback from the user** — the branch may not have diverged, may be the
+wrong branch, or the base may be wrong. Do not proceed.
+
+### 4. Draft title and body
+
+From the commits and diff, draft:
+
+- A concise, imperative **title** (mirror the commit subject if there is a single
+  commit; otherwise summarize the branch).
+- A **body** with a short summary of what changed and why, plus a brief bullet
+  list of notable changes. Keep it factual to the diff.
+
+Present the forge, target branch, tool invocation, drafted title, and body to the
+user and **ask for explicit approval**. Offer them the chance to edit before
+proceeding.
+
+### 5. Create the PR/MR (only after approval)
+
+Use the resolved tool prefix. Try-and-see — do not pre-check the push state.
+
+GitHub (`gh`):
+
+```bash
+gh pr create --base "$DEFAULT" --head "$CURRENT" \
+  --title "<approved title>" --body "<approved body>"
+```
+
+GitLab (`glab`):
+
+```bash
+glab mr create --target-branch "$DEFAULT" --source-branch "$CURRENT" \
+  --title "<approved title>" --description "<approved body>"
+```
+
+If the command fails because the branch is not on the remote, report the exact
+error and ask the user whether to push (e.g. `git push -u origin "$CURRENT"`) and
+retry. Do not push automatically unless the user approves.
+
+On success, share the PR/MR URL returned by the CLI.
+
+## Notes
+
+- Pass multi-line bodies safely, e.g. write the body to a temp file and use
+  `--body-file` (gh) / `--description "$(cat file)"` (glab), or a quoted heredoc.
+- `gh`/`glab` handle authentication themselves; do not attempt to manage tokens.

--- a/home-manager/pi/skills/create-pr/scripts/default-branch.sh
+++ b/home-manager/pi/skills/create-pr/scripts/default-branch.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Print the default branch of the repo without hitting the network.
+# Prints the short branch name (e.g. "main") or nothing on failure.
+set -euo pipefail
+
+remote="${1:-origin}"
+
+# 1. Symbolic ref set by `git remote set-head` / clone.
+if ref="$(git symbolic-ref -q --short "refs/remotes/$remote/HEAD" 2>/dev/null)"; then
+  printf '%s\n' "${ref#"$remote"/}"
+  exit 0
+fi
+
+# 2. Common conventional names that exist locally as remote-tracking refs.
+for b in main master trunk develop; do
+  if git show-ref -q --verify "refs/remotes/$remote/$b" 2>/dev/null; then
+    printf '%s\n' "$b"
+    exit 0
+  fi
+done
+
+# 3. Local branches as a last resort.
+for b in main master trunk develop; do
+  if git show-ref -q --verify "refs/heads/$b" 2>/dev/null; then
+    printf '%s\n' "$b"
+    exit 0
+  fi
+done
+
+exit 1

--- a/home-manager/pi/skills/create-pr/scripts/detect-forge.sh
+++ b/home-manager/pi/skills/create-pr/scripts/detect-forge.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Best-effort forge detection from git remotes.
+# Prints one of: github | gitlab | unknown
+#
+# "unknown" means the caller MUST elicit feedback from the user rather
+# than guessing. Self-hosted instances often do not carry github/gitlab
+# in the hostname, so treat "unknown" as an expected outcome.
+set -euo pipefail
+
+remote="${1:-origin}"
+
+url="$(git remote get-url "$remote" 2>/dev/null || true)"
+if [ -z "$url" ]; then
+  # Fall back to the first configured remote, if any.
+  first="$(git remote 2>/dev/null | head -n1 || true)"
+  if [ -n "$first" ]; then
+    url="$(git remote get-url "$first" 2>/dev/null || true)"
+  fi
+fi
+
+if [ -z "$url" ]; then
+  echo "unknown"
+  exit 0
+fi
+
+case "$url" in
+  *github.com*) echo "github" ;;
+  *gitlab*)     echo "gitlab" ;;
+  *)            echo "unknown" ;;
+esac

--- a/home-manager/pi/skills/create-pr/scripts/resolve-tool.sh
+++ b/home-manager/pi/skills/create-pr/scripts/resolve-tool.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Resolve the invocation for a forge CLI tool (e.g. gh, glab).
+#
+# Search order (per skill requirements):
+#   1. ~/.nix-profile/bin/<tool>
+#   2. mise (via `mise exec -- <tool>`)
+#   3. system-wide (/usr/local/bin, /usr/bin)
+#
+# On success prints the command prefix to invoke the tool and exits 0.
+# On failure prints an error to stderr and exits 1 (caller MUST bail).
+set -euo pipefail
+
+tool="${1:?usage: resolve-tool.sh <tool-name>}"
+
+# 1. Nix profile
+if [ -x "$HOME/.nix-profile/bin/$tool" ]; then
+  printf '%s\n' "$HOME/.nix-profile/bin/$tool"
+  exit 0
+fi
+
+# 2. mise
+if command -v mise >/dev/null 2>&1; then
+  if mise which "$tool" >/dev/null 2>&1; then
+    printf 'mise exec -- %s\n' "$tool"
+    exit 0
+  fi
+fi
+
+# 3. System-wide
+for p in "/usr/local/bin/$tool" "/usr/bin/$tool"; do
+  if [ -x "$p" ]; then
+    printf '%s\n' "$p"
+    exit 0
+  fi
+done
+
+echo "ERROR: '$tool' not found in ~/.nix-profile/bin, via mise, or in /usr/local/bin /usr/bin" >&2
+echo "Install '$tool' in one of those locations before creating a PR/MR." >&2
+exit 1

--- a/home-manager/terminal/llm.nix
+++ b/home-manager/terminal/llm.nix
@@ -116,6 +116,40 @@ in
       "pageDown"
       "ctrl+v"
     ];
+
+    # App-level bindings carried over from the previously hand-managed
+    # ~/.pi/agent/keybindings.json so nothing regresses on the Linux hosts.
+    "app.message.dequeue" = [
+      "alt+up"
+      "alt+p"
+    ];
+    "app.tree.foldOrUp" = [
+      "ctrl+left"
+      "alt+left"
+      "ctrl+b"
+    ];
+    "app.tree.unfoldOrDown" = [
+      "ctrl+right"
+      "alt+right"
+      "ctrl+f"
+    ];
+    "app.session.togglePath" = [ "alt+p" ];
+    "app.session.toggleNamedFilter" = [ "alt+n" ];
+    "app.models.toggleProvider" = [ "alt+g" ];
+    "app.models.reorderUp" = [
+      "alt+up"
+      "alt+p"
+    ];
+    "app.models.reorderDown" = [
+      "alt+down"
+      "alt+n"
+    ];
   };
+
+  # Global agent guidelines and skills, previously unmanaged real files under
+  # ~/.pi/agent. settings.json is intentionally left out for now because pi
+  # mutates it at runtime (e.g. lastChangelogVersion).
+  home.file.".pi/agent/AGENTS.md".source = ../pi/AGENTS.md;
+  home.file.".pi/agent/skills".source = ../pi/skills;
 
 }


### PR DESCRIPTION
Stacked on #298. Manages the previously hand-maintained `~/.pi/agent` files via
Home Manager so all Pi config is declarative.

- **llm.nix**: merge the app-level keybindings that only lived in the live
  `~/.pi/agent/keybindings.json` into the nix-generated file, so the Linux hosts
  don't regress on top of #298's macOS-oriented set.
- Track the global `AGENTS.md` and `skills/` under `home-manager/pi/` and link
  them into `~/.pi/agent` via `home.file`.

Left out intentionally: `settings.json` (pi mutates it at runtime), plus
`auth.json` / `sessions/` / logs.
