### PR TITLE
Separate update cadence for caddy

### DIFF
--- a/.github/workflows/caddy-hash.yaml
+++ b/.github/workflows/caddy-hash.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     paths:
       - 'nixos/tiniboi/caddy.nix'
-      - 'flake.lock'
+      - 'flake.nix'
 
 permissions: {}
 
@@ -27,20 +27,28 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - run: |
+          # Renovate's regex manager bumps the nixpkgs-caddy commit in flake.nix but
+          # does not touch flake.lock; re-lock so the new caddy version is used.
+          nix flake lock
           if build_output=$(nix build .#nixosConfigurations.tiniboi.config.services.caddy.package 2>&1); then
-            echo "::notice::Caddy doesn't require any updates"
-            exit 0
+            echo "::notice::Caddy builds with the pinned hash"
+          else
+            correct_hash=$(printf '%s' "$build_output" | grep -oP 'got:\s+\K(sha256-[A-Za-z0-9+/]+=)' | head -1)
+            if [[ -z "$correct_hash" ]]; then
+              echo "::error::Build failed; no hash mismatch identified. ${build_output}"
+              exit 1
+            fi
+            sed -i "s|hash = \"sha256-[^\"]*\";|hash = \"${correct_hash}\";|" nixos/tiniboi/caddy.nix
+            nix build .#nixosConfigurations.tiniboi.config.services.caddy.package
+            echo "Caddy vendor hash updated to $correct_hash" >> "$GITHUB_STEP_SUMMARY"
           fi
-          correct_hash=$(printf '%s' "$build_output" | grep -oP 'got:\s+\K(sha256-[A-Za-z0-9+/]+=)' | head -1)
-          if [[ -z "$correct_hash" ]]; then
-            echo "::error::Build failed; no hash mismatch identified. %OA${build_output}"
-            exit 1
+          # Commit the lock re-sync and/or hash fix, if anything changed.
+          if ! git diff --quiet -- flake.lock nixos/tiniboi/caddy.nix; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add flake.lock nixos/tiniboi/caddy.nix
+            git commit -m "fix(caddy): sync lock and vendor hash"
+            git push
+          else
+            echo "::notice::Caddy requires no lock or hash changes"
           fi
-          sed -i "s|hash = \"sha256-[^\"]*\";|hash = \"${correct_hash}\";|" nixos/tiniboi/caddy.nix
-          nix build .#nixosConfigurations.tiniboi.config.services.caddy.package
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add nixos/tiniboi/caddy.nix
-          git commit -m "fix(caddy): update vendor hash"
-          git push
-          echo "Caddy build hash output updated to $correct_hash" >> "$GITHUB_STEP_SUMMARY"

--- a/flake.lock
+++ b/flake.lock
@@ -177,6 +177,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-caddy": {
+      "locked": {
+        "lastModified": 1780336545,
+        "narHash": "sha256-vhVhuXzFrIOfcssC/9hDHx7MHzDKjF3keHuREOQqQiQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4df1b885d76a54e1aa1a318f8d16fd6005b6401f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4df1b885d76a54e1aa1a318f8d16fd6005b6401f",
+        "type": "github"
+      }
+    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1779796641,
@@ -215,6 +231,7 @@
         "llm-agents": "llm-agents",
         "nixgl": "nixgl",
         "nixpkgs": "nixpkgs_2",
+        "nixpkgs-caddy": "nixpkgs-caddy",
         "nixpkgs-stable": "nixpkgs-stable",
         "sops-nix": "sops-nix"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,14 @@
 
     nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-25.11";
 
+    # Dedicated nixpkgs pin for caddy so its FOD vendor hash only churns when this
+    # input is bumped, not on weekly lockfile maintenance. Kept as a fixed commit on
+    # purpose: `nix flake update` cannot move a commit-pinned input, so weekly
+    # maintenance leaves caddy untouched. Renovate bumps this commit monthly via the
+    # `nixpkgs-caddy` customManager in renovate.json; the caddy-hash workflow then
+    # syncs flake.lock and fixes the vendor hash.
+    nixpkgs-caddy.url = "github:nixos/nixpkgs/4df1b885d76a54e1aa1a318f8d16fd6005b6401f";
+
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -30,6 +38,7 @@
   outputs =
     {
       nixpkgs,
+      nixpkgs-caddy,
       home-manager,
       nixgl,
       llm-agents,
@@ -154,7 +163,10 @@
         };
         tiniboi = nixpkgs.lib.nixosSystem {
           system = "x86_64-linux";
-          specialArgs = { inherit syncthingDevices; };
+          specialArgs = {
+            inherit syncthingDevices;
+            pkgsCaddy = nixpkgs-caddy.legacyPackages."x86_64-linux";
+          };
           modules = [
             ./nixos/tiniboi.nix
             sops-nix.nixosModules.sops

--- a/nixos/tiniboi/caddy.nix
+++ b/nixos/tiniboi/caddy.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   pkgs,
+  pkgsCaddy,
   ...
 }:
 
@@ -17,7 +18,7 @@
 
   services.caddy = {
     enable = true;
-    package = pkgs.caddy.withPlugins {
+    package = pkgsCaddy.caddy.withPlugins {
       plugins = [ "github.com/caddy-dns/cloudflare@v0.2.4" ];
       # Run `nix build .#nixosConfigurations.tiniboi.config.services.caddy.package` to get the correct hash
       hash = "sha256-bzMqxWTqrJ1skZmRTXyEMCKStXpljbqe5r0Ve2cnBfM=";

--- a/renovate.json
+++ b/renovate.json
@@ -31,9 +31,41 @@
       ],
       "depNameTemplate": "github.com/caddy-dns/cloudflare",
       "datasourceTemplate": "go"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^flake\\.nix$/"],
+      "matchStrings": [
+        "nixpkgs-caddy\\.url = \"github:nixos/nixpkgs/(?<currentDigest>[0-9a-f]{7,40})\""
+      ],
+      "currentValueTemplate": "nixos-unstable",
+      "depNameTemplate": "nixpkgs-caddy",
+      "packageNameTemplate": "https://github.com/nixos/nixpkgs",
+      "datasourceTemplate": "git-refs"
     }
   ],
   "packageRules": [
+    {
+      "description": "Bundle caddy's nixpkgs pin + cloudflare plugin into one monthly PR; the caddy-hash workflow syncs the lock and vendor hash",
+      "matchDepNames": [
+        "nixpkgs-caddy",
+        "github.com/caddy-dns/cloudflare"
+      ],
+      "groupName": "caddy",
+      "schedule": [
+        "on the first day of the month"
+      ]
+    },
+    {
+      "description": "Only the custom regex manager may bump the caddy nixpkgs pin; disable the built-in nix manager for it so the two don't emit conflicting digest updates",
+      "matchManagers": [
+        "nix"
+      ],
+      "matchDepNames": [
+        "nixpkgs-caddy"
+      ],
+      "enabled": false
+    },
     {
       "matchPackageNames": [
         "/immich/"


### PR DESCRIPTION
This should make caddy updates be separate from the rest of packages.
